### PR TITLE
Forward SerialPort error event

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ import { EnttecOpenDMXUSBDevice as DMXDevice } from "enttec-open-dmx-usb";
 ## Events
 `ready` - `startSending` can be called.
 
-`error` - An error occurred.
+`error` - An error occurred. The error can also originate from SerialPort.

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,13 @@ export class EnttecOpenDMXUSBDevice extends EventEmitter<Events> {
       this.emit("ready")
       if (startSending) this.startSending(0)
     })
+    // Forward SerialPort errors.
+    // If nothing is attaching to the SerialPort error event, the Node process will be terminated
+    // in case of an error (e.g. wrong device passed) which would not permit error handling in
+    // projects using this package.
+    this.port.on("error", (error: Error) => {
+      this.emit("error", error)
+    })
   }
 
   /**


### PR DESCRIPTION
Thanks @moritzruth for this package which works out of the box!

I'm having an issue when no device is connected, which happens when I run unit tests on my laptop where part of the code tries to open a connection to the DMX device. The PR fixes that.

(I'd be happy about a patch release then! :))